### PR TITLE
Crash and restart on memory error

### DIFF
--- a/deployment/prod_env/docker-compose.yml
+++ b/deployment/prod_env/docker-compose.yml
@@ -32,104 +32,113 @@ services:
     image: openlmis/requisition:8.3.4
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx3072m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration'
+      JAVA_OPTS: '-server -Xmx3072m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   referencedata:
     restart: always
     image: openlmis/referencedata:15.2.3
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx2560m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration'
+      JAVA_OPTS: '-server -Xmx2560m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   auth:
     restart: always
     image: openlmis/auth:4.3.3
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx768m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration'
+      JAVA_OPTS: '-server -Xmx768m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   notification:
     restart: always
     image: openlmis/notification:4.3.3
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   fulfillment:
     restart: always
     image: openlmis/fulfillment:9.0.3
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx768m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration'
+      JAVA_OPTS: '-server -Xmx768m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   reports:
     image: openlmismw/reports:2.1.2
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx3072m -Xss1024k -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration'
+      JAVA_OPTS: '-server -Xmx3072m -Xss1024k -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   dhis2-integration:
     image: openlmismw/dhis2-integration:1.0.4
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration'
+      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   stockmanagement:
     image: openlmis/stockmanagement:5.1.6
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration'
+      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml -Dflyway.locations=classpath:db/migration -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   hapifhir:
     image: openlmis/hapifhir:2.0.2
     env_file: .env
     environment:
-      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
   log:
     restart: always


### PR DESCRIPTION
This is a band-aid fix for out of memory errors we are seeing from time
to time. With this configuration, the service that runs out of heap memory
will crash and Docker will restart it.

This a fix for a situation we are observing - a service runs out of memory
and then is stuck in a broken state.